### PR TITLE
WIP: add ability to bridge Riverpod providers

### DIFF
--- a/example/lib/load_with_riverpod_future_provider.dart
+++ b/example/lib/load_with_riverpod_future_provider.dart
@@ -1,0 +1,88 @@
+library load_with_riverpod_future_provider;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_forge/flutter_forge.dart';
+
+final nameProvider = FutureProvider<String>((ref) async {
+  return Future.delayed(const Duration(seconds: 5), () {
+    return "The Loaded Name";
+  });
+});
+
+// State definition
+@immutable
+class State {
+  const State({required this.count, required this.name});
+  final int count;
+  final AsyncValue<String> name;
+}
+
+class Environment {}
+
+// Actions
+abstract class LoadWithRiverpodFutureProviderAction implements ReducerAction {}
+
+class Increment implements LoadWithRiverpodFutureProviderAction {}
+
+// Reducer
+final loadWithRiverpodFutureProviderReducer =
+    Reducer<State, Environment, LoadWithRiverpodFutureProviderAction>(
+        (State state, LoadWithRiverpodFutureProviderAction action) {
+  if (action is Increment) {
+    return ReducerTuple(State(count: state.count + 1, name: state.name), []);
+  } else {
+    return ReducerTuple(state, []);
+  }
+});
+
+// Stateful Widget
+class LoadWithRiverpodFutureProviderComponentWidget
+    extends ComponentWidget<State, LoadWithRiverpodFutureProviderAction> {
+  LoadWithRiverpodFutureProviderComponentWidget(
+      {super.key,
+      StoreInterface<State, LoadWithRiverpodFutureProviderAction>? store})
+      : super(
+            store: store ??
+                Store(
+                  initialState:
+                      const State(count: 0, name: AsyncValue.data("Initial")),
+                  reducer: loadWithRiverpodFutureProviderReducer,
+                  environment: Environment(),
+                  extProviderConnector: ExternalProviderConnector(
+                    provider: nameProvider,
+                    fromExtState: (state, subState) =>
+                        State(count: state.count, name: subState),
+                  ),
+                ));
+
+  @override
+  Widget build(context, state, viewStore) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Load With Riverpod Future Provider Component'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Column(children: [
+              state.name.when(
+                data: (data) => Text(data),
+                error: (_, __) => const Text("Some error"),
+                loading: () => const Text("Loading..."),
+              ),
+              Text(
+                '${state.count}',
+                style: Theme.of(context).textTheme.headline4,
+              ),
+              OutlinedButton(
+                  onPressed: () => viewStore.send(Increment()),
+                  child: const Text("increment"))
+            ])
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,6 +7,7 @@ import 'compose_with_parent_owning_state.dart'
     as compose_with_parent_owning_state;
 import 'compose_component_owning_state.dart' as compose_component_owning_state;
 import 'load_on_component_init.dart' as load_on_component_init;
+import 'load_with_riverpod_future_provider.dart';
 import 'override_ui.dart' as override_ui;
 
 void main() {
@@ -111,6 +112,19 @@ class Home extends StatelessWidget {
                             const TriggerNavByChildComponent()));
               },
               child: const Text('Trigger Nav by Child Component'),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) =>
+                            LoadWithRiverpodFutureProviderComponentWidget()));
+              },
+              child: const Text('Load With Riverpod Future Provider'),
             ),
           ),
         ])));

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -6,18 +6,46 @@ import 'state_management/view_store.dart';
 import 'state_management/reducer.dart';
 import 'scoped_store.dart';
 
-class Store<S, E, A extends ReducerAction> extends StoreInterface<S, A> {
+externalProvider<S, SS, E, A extends ReducerAction>(
+    NotifierProvider<ViewStore<S, E, A>, S> storeProvider,
+    AlwaysAliveProviderListenable<SS> provider,
+    S Function(S, SS) toState) {
+  return Provider<S>((ref) {
+    final storeState = ref.watch(storeProvider);
+    final externalProviderState = ref.watch(provider);
+    return toState(storeState, externalProviderState);
+  });
+}
+
+class ExternalProviderConnector<S, SS> {
+  final AlwaysAliveProviderListenable<SS> provider;
+  final S Function(S, SS) fromExtState;
+
+  ExternalProviderConnector(
+      {required this.provider, required this.fromExtState});
+}
+
+class Store<S, E, A extends ReducerAction, SS> extends StoreInterface<S, A> {
   Store(
       {required S initialState,
       required Reducer<S, E, A> reducer,
-      required E environment})
+      required E environment,
+      ExternalProviderConnector<S, SS>? extProviderConnector})
       : _notifierProvider =
-            viewStoreProvider(initialState, reducer, environment);
+            viewStoreProvider(initialState, reducer, environment) {
+    if (extProviderConnector == null) {
+      _provider = _notifierProvider;
+    } else {
+      _provider = externalProvider(_notifierProvider,
+          extProviderConnector.provider, extProviderConnector.fromExtState);
+    }
+  }
   final NotifierProvider<ViewStore<S, E, A>, S> _notifierProvider;
+  late final AlwaysAliveProviderListenable<S> _provider;
 
   @override
   AlwaysAliveProviderListenable<S> get provider {
-    return _notifierProvider;
+    return _provider;
   }
 
   @override


### PR DESCRIPTION
Add the ability to bridge a Riverpod provider into Flutter Forge so that
we could use Riverpod to fetch and cache data more easily.

One thing that needs to be thought through is the modularization &
isolation of the component when using external Riverpod providers this
way.

We may decide that this mechanism isn't what we want and we want a
completely different startegy.

This is just a first swag at how this might be possible.

<!-- ps-id: fdc912c2-a806-4cf0-9a6f-1077f863c55b -->